### PR TITLE
Added pytest-mock and pyassert packages

### DIFF
--- a/src/docker/pytango_ska_dev/Pipfile
+++ b/src/docker/pytango_ska_dev/Pipfile
@@ -10,7 +10,10 @@ verify_ssl = true
 
 [packages]
 mock = "*"
+pyassert = "*"
+# pact-python = "*"  # requires gcc so will need a layered build
 pytest = "*"
+pytest-mock = "*"
 pytest_bdd = "*"
 pytest-codestyle = "*"
 pytest-pydocstyle = "*"

--- a/src/docker/pytango_ska_dev/Pipfile.lock
+++ b/src/docker/pytango_ska_dev/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2c3c155c1b0f28cc3199ead7031494738e7e4d48acdbb46dea8a091b139596cf"
+            "sha256": "e7722c38351f4d3aeb50cc46c251c9588f6cee76496952fcfcdef42954e9fcdb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -210,6 +210,13 @@
             ],
             "version": "==1.8.0"
         },
+        "pyassert": {
+            "hashes": [
+                "sha256:ccae35ca67605f997d97f94b8f2ef0e57fb42274fec5c67571f127a378fa10d4"
+            ],
+            "index": "pypi",
+            "version": "==0.4.2"
+        },
         "pycodestyle": {
             "hashes": [
                 "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
@@ -259,6 +266,14 @@
             ],
             "index": "pypi",
             "version": "==2.7.1"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:43ce4e9dd5074993e7c021bb1c22cbb5363e612a2b5a76bc6d956775b10758b7",
+                "sha256:5bf5771b1db93beac965a7347dc81c675ec4090cb841e49d9d34637a25c30568"
+            ],
+            "index": "pypi",
+            "version": "==1.10.4"
         },
         "pytest-pydocstyle": {
             "hashes": [


### PR DESCRIPTION
Very minor PR to add the pyassert and pytest-mock packages to the ORCA python tango development container. The docker image for this change has already been published to dockerhub (https://hub.docker.com/r/skaorca/pytango_ska_dev/tags) under the tags `0.1.0-53867879` and `latest`.

I also also tried to add the `pact-python` package, but this requires gcc to install so will need a modification of the Dockerfile. As a result, this package is currently disabled in the Pipfile.

There is no testing of the container at the moment.

