### PR TITLE
Removed lmc-base-classes submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/lmc-base-classes"]
-	path = src/lmc-base-classes
-	url = https://github.com/ska-telescope/lmc-base-classes


### PR DESCRIPTION
This is not required. If base class XMI files are needed for pogo,
set the inheritance root directory in the pogo edit->preferences
menu to a cloned copy of the lmc base class repo.

An example of this is shown below:

![Screenshot 2019-07-13 at 15 54 45](https://user-images.githubusercontent.com/143909/61173120-a2f9ee80-a586-11e9-92bb-64c955b13386.png)
