### PR TITLE
Only update XRay test results from master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,6 +24,8 @@ subarray_tests:
 # Update XRAY links in JIRA
 xray:
   stage: posttest
+  only:
+    - master
   #tags: [ska]
   before_script: []
   #This line may require the magic setting of cache earlier on.


### PR DESCRIPTION
This prevents test executions for branches appearing in XRay.