### PR TITLE
Updated ReadtheDocs project to reflect new repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![pipeline status](https://gitlab.com/ska-telescope/sdp-prototype/badges/master/pipeline.svg)](https://gitlab.com/ska-telescope/sdp-prototype/pipelines)
-[![Documentation Status](https://readthedocs.org/projects/sdp-configuration-prototype/badge/?version=latest)](https://sdp-configuration-prototype.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/sdp-prototype/badge/?version=latest)](https://sdp-prototype.readthedocs.io/en/latest/?badge=latest)
 
 # SDP Evolutionary Prototype
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,21 @@
+# .readthedocs.yml
+# Read the Docs configuration file.
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/src/ directory with Sphinx
+sphinx:
+  configuration: docs/src/conf.py
+
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of the Python and requirements required to build
+#  your docs
+python:
+    version: 3.7
+    install:
+      - requirements: docs/requirements.txt


### PR DESCRIPTION
- Added readthedocs configuration file
- Updated url of the documentation badge in the top level README.md file

The readthedocs configuration file is now the preferred way of updating settings on the readthedocs project. For details see https://docs.readthedocs.io/en/stable/config-file/v2.html 