### PR TITLE
Fix to the coverage badge (and restructure of CI jobs/stages)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ stages:
 # Set up caching as suggested by GitLab's Python template
 variables:
   PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
-  cache:
+cache:
     paths: [.cache/pip,venv]
 
 # Test the SDPSubarray device

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ coverage:
     - coverage html
   script:
     - mv htmlcov/ public/
-  coverage: '^TOTAL\s+\d+\s+\d+\s+(\d+\%)$'
+  coverage: '/TOTAL\s+\d+\s+\d+\s+\d+\s+\d+\s+(\d+\%)/'
   artifacts:
     paths:
       - public/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,18 +1,18 @@
 image: "python:latest"
 
-## Set up caching as suggested by GitLab's Python template
-#variables:
-#  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
-#cache:
-#  paths: [.cache/pip,venv]
-
-
 # Note: Tests can be run locally with
 #   gitlab-runner exec <executor, eg. docker> <stage name>
 
 stages:
   - test
-  - posttest
+  - post_test
+  - deploy
+
+# Set up caching as suggested by GitLab's Python template
+variables:
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
+  cache:
+    paths: [.cache/pip,venv]
 
 # Test the SDPSubarray device
 subarray_tests:
@@ -29,11 +29,9 @@ subarray_tests:
       paths:
       - cucumber.json
       - $CI_JOB_NAME.coverage
-      expire_in: 30 days
-      when: always
+      expire_in: 1 week
 
 # Test the SDPMaster device.
-# Run locally with: gitlab-runner exec docker master_tests
 master_tests:
     stage: test
     image: skaorca/pytango_ska_dev:latest
@@ -44,30 +42,37 @@ master_tests:
       paths:
         - $CI_JOB_NAME.coverage
 
-# Update XRay links in JIRA
+# Generate combined test coverage report
+coverage_report:
+  stage: post_test
+  before_script:
+    - pip install coverage
+  script:
+    - coverage combine *.coverage
+    - coverage report
+    - coverage html
+  coverage: '/TOTAL\s+\d+\s+\d+\s+\d+\s+\d+\s+(\d+\%)/'
+  artifacts:
+    paths: [htmlcov/]
+    expire_in: 1 week
+
+# Update XRay links in JIRA. This is done only for the master
 xray:
-  stage: posttest
-  only:
-    - master
+  stage: post_test
+  only: [master]
   script:
     - 'curl -X POST -H "Content-Type: application/json"
          -H "Authorization: Basic $JIRA_AUTH"
          --data @cucumber.json
          https://jira.skatelescope.org/rest/raven/1.0/import/execution/cucumber'
-  retry: 2 #In case JIRA doesn't work first time
+  retry: 2 # In case JIRA doesn't work first time
 
-# Generate and publish coverage report
-coverage:
-  stage: posttest
-  before_script:
-    - pip install coverage
-    - coverage combine *.coverage
-    - coverage report
-    - coverage html
+# Generate gitlab pages. This is done only for the master.
+pages:
+  stage: deploy
+  only: [master]
   script:
-    - mv htmlcov/ public/
-  coverage: '/TOTAL\s+\d+\s+\d+\s+\d+\s+\d+\s+(\d+\%)/'
+    - cp -R htmlcov public/
   artifacts:
-    paths:
-      - public/
+    paths: [public/]
     expire_in: 1 week

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,8 +56,8 @@ xray:
          https://jira.skatelescope.org/rest/raven/1.0/import/execution/cucumber'
   retry: 2 #In case JIRA doesn't work first time
 
-# Publish Coverage reports
-pages:
+# Generate and publish coverage report
+coverage:
   stage: posttest
   before_script:
     - pip install coverage
@@ -66,6 +66,7 @@ pages:
     - coverage html
   script:
     - mv htmlcov/ public/
+  coverage: '^TOTAL\s+\d+\s+\d+\s+(\d+\%)$'
   artifacts:
     paths:
       - public/


### PR DESCRIPTION
Specifies the regex used to capture the code coverage in the CI stage rather than globally.

The badge will not be fixed until the code is in master the badge is reporting the coverage on master.

A sneak preview of it working however can be seen by generating the badge for the branch ie.

[![coverage report](https://gitlab.com/ska-telescope/sdp-prototype/badges/fix_coverage_badge/coverage.svg)](https://gitlab.com/ska-telescope/sdp-prototype/commits/fix_coverage_badge)

(thanks to @scpmw for the suggestions that lead to finding this fix)