### PR TITLE
Get Docker Image release version from `release.py`

### DIFF
--- a/src/tango_sdp_master/Makefile
+++ b/src/tango_sdp_master/Makefile
@@ -4,7 +4,7 @@
 
 NAME=tangods_sdp_master
 CLASS=SDPMaster
-VERSION=$(shell awk -F= '/^VERSION =/{print $$2}' $(CLASS)/release.py)
+VERSION=$(strip $(shell awk -F= '/^VERSION = ".*"/{print $$2}' $(CLASS)/release.py))
 
 include ../make/Makefile
 

--- a/src/tango_sdp_master/Makefile
+++ b/src/tango_sdp_master/Makefile
@@ -1,13 +1,10 @@
 #
-# Makefile fuctions for the SDP Master Tango device
+# Makefile utility functions for the SDP Master Tango device
 #
 
 NAME=tangods_sdp_master
 CLASS=SDPMaster
-VERSION=$(shell python3 -c "import os; \
-	release = {}; \
-	exec(open(os.path.join('$(CLASS)', 'release.py')).read(), release); \
-	print(release['VERSION'])")
+VERSION=$(shell awk -F= '/^VERSION =/{print $$2}' $(CLASS)/release.py)
 
 include ../make/Makefile
 

--- a/src/tango_sdp_master/Makefile
+++ b/src/tango_sdp_master/Makefile
@@ -4,7 +4,10 @@
 
 NAME=tangods_sdp_master
 CLASS=SDPMaster
-VERSION=0.2.0
+VERSION=$(shell python3 -c "import os; \
+	release = {}; \
+	exec(open(os.path.join('$(CLASS)', 'release.py')).read(), release); \
+	print(release['VERSION'])")
 
 include ../make/Makefile
 

--- a/src/tango_sdp_master/SDPMaster/release.py
+++ b/src/tango_sdp_master/SDPMaster/release.py
@@ -3,7 +3,7 @@
 
 NAME = "ska-sdp-master"
 # For version names see: https://www.python.org/dev/peps/pep-0440/
-VERSION = "0.2.0"
+VERSION = "0.2.1"
 VERSION_INFO = VERSION.split(".")
 AUTHOR = "ORCA Team"
 LICENSE = 'License :: OSI Approved :: BSD License'

--- a/src/tango_sdp_subarray/Makefile
+++ b/src/tango_sdp_subarray/Makefile
@@ -4,7 +4,10 @@
 
 NAME=tangods_sdp_subarray
 CLASS=SDPSubarray
-VERSION=0.2.0
+VERSION=$(shell python3 -c "import os; \
+	release = {}; \
+	exec(open(os.path.join('$(CLASS)', 'release.py')).read(), release); \
+	print(release['VERSION'])")
 
 include ../make/Makefile
 

--- a/src/tango_sdp_subarray/Makefile
+++ b/src/tango_sdp_subarray/Makefile
@@ -1,13 +1,10 @@
 #
-# Makefile for building and publishing the `tangods_sdp_subarray` image.
+#  Makefile utility functions for the SDP Subarray Tango device
 #
 
 NAME=tangods_sdp_subarray
 CLASS=SDPSubarray
-VERSION=$(shell python3 -c "import os; \
-	release = {}; \
-	exec(open(os.path.join('$(CLASS)', 'release.py')).read(), release); \
-	print(release['VERSION'])")
+VERSION=$(shell awk -F= '/^VERSION =/{print $$2}' $(CLASS)/release.py)
 
 include ../make/Makefile
 

--- a/src/tango_sdp_subarray/Makefile
+++ b/src/tango_sdp_subarray/Makefile
@@ -4,7 +4,7 @@
 
 NAME=tangods_sdp_subarray
 CLASS=SDPSubarray
-VERSION=$(shell awk -F= '/^VERSION =/{print $$2}' $(CLASS)/release.py)
+VERSION=$(strip $(shell awk -F= '/^VERSION = ".*"/{print $$2}' $(CLASS)/release.py))
 
 include ../make/Makefile
 


### PR DESCRIPTION
Read the Docker image version from the `release.py` file in the makefile using `awk`.
This avoids having two places where the VERSION is defined.

Also updated SDPMaster to VERSION = 0.2.1 to reflect addition of healthState attribute.