### PR TITLE
Remove quotes from VERSION variable in makefile

### DIFF
--- a/src/tango_sdp_master/Makefile
+++ b/src/tango_sdp_master/Makefile
@@ -4,7 +4,7 @@
 
 NAME=tangods_sdp_master
 CLASS=SDPMaster
-VERSION=$(strip $(shell awk -F= '/^VERSION = ".*"/{print $$2}' $(CLASS)/release.py))
+VERSION=$(patsubst "%",%, $(shell awk -F= '/^VERSION = ".*"/{print $$2}' $(CLASS)/release.py))
 
 include ../make/Makefile
 

--- a/src/tango_sdp_subarray/Makefile
+++ b/src/tango_sdp_subarray/Makefile
@@ -4,7 +4,7 @@
 
 NAME=tangods_sdp_subarray
 CLASS=SDPSubarray
-VERSION=$(strip $(shell awk -F= '/^VERSION = ".*"/{print $$2}' $(CLASS)/release.py))
+VERSION=$(patsubst "%",%, $(shell awk -F= '/^VERSION = ".*"/{print $$2}' $(CLASS)/release.py))
 
 include ../make/Makefile
 


### PR DESCRIPTION
Very minor fix to remove the quotes around the VERSION extracted by awk.