### PR TITLE
Build and publish Python packages SDP Tango devices in the CI script [ORCA-114]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -138,9 +138,10 @@ xray_report-manual:
     - cd $BUILD_PATH
     - python setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
     - ls
+    - ls dist/
   artifacts:
     paths:
-      - ./dist/
+      - ./$BUILD_PATH/dist/
 
 build:ska-sdp-master:
   extends: .build_python

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,7 +135,7 @@ xray_report-manual:
     - docker
     - engageska
   script:
-    - cd BUILD_PATH
+    - cd $BUILD_PATH
     - python setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -137,6 +137,7 @@ xray_report-manual:
   script:
     - cd $BUILD_PATH
     - python setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+    - ls
   artifacts:
     paths:
       - ./dist/
@@ -144,7 +145,7 @@ xray_report-manual:
 build:ska-sdp-master:
   extends: .build_python
   variables:
-    BUILD_PATH: docker/pytango_base
+    BUILD_PATH: src/tango_sdp_master
 
 build:ska-sdp-subarray:
   extends: .build_python

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,8 +6,8 @@ stages:
   - test
   - post_test
   - build
-  - stage
-  - deploy
+  - publish
+  - pages
 
 # ============================================================================
 # Run linters & tests
@@ -124,6 +124,48 @@ xray_report-manual:
   when: manual
   except: [master]
 
+# ============================================================================
+# Build python packages
+# ============================================================================
+
+.build_python:
+  stage: build
+  image: nexus.engageska-portugal.pt/sdp-prototype/pytango_ska_dev:latest
+  tags:
+    - docker
+    - engageska
+  script:
+    - cd $BUILD_DIR
+    - python setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+  artifacts:
+    paths:
+      - ./dist/
+
+build:ska-sdp-master:
+  extends: .build_python
+  variables:
+    BUILD_PATH: src/tango_sdp_master
+
+build:ska-sdp-subarray:
+  extends: .build_python
+  variables:
+    BUILD_PATH: src/tango_sdp_subarray
+
+# ============================================================================
+# Publish python packages
+# ============================================================================
+
+#publish_to_nexus:
+#  stage: publish
+#  image: nexus.engageska-portugal.pt/sdp-prototype/pytango_ska_dev:latest
+#  tags:
+#    - docker
+#    - engageska
+#  before_script:
+#    - pip install twine
+#  script:
+#    - python setup.py sdist bdist_wheel
+#    - twine upload dist/*
 
 # ============================================================================
 # Build docker images
@@ -206,7 +248,7 @@ build:tangods_sdp_subarray:
 # ============================================================================
 
 .push_docker:
-  stage: deploy
+  stage: publish
   variables:
     DOCKER_REGISTRY_HOST: $DOCKER_REGISTRY_HOST
     DOCKER_REGISTRY_USER: $CI_PROJECT_NAME
@@ -296,7 +338,7 @@ push:tangods_sdp_subarray-manual:
 
 # Generate gitlab pages.
 pages:
-  stage: deploy
+  stage: pages
   tags: [docker]
   only: [master]
   image: python:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,7 +135,7 @@ xray_report-manual:
     - docker
     - engageska
   script:
-    - cd $BUILD_DIR
+    - cd BUILD_PATH
     - python setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   artifacts:
     paths:
@@ -144,7 +144,7 @@ xray_report-manual:
 build:ska-sdp-master:
   extends: .build_python
   variables:
-    BUILD_PATH: src/tango_sdp_master
+    BUILD_PATH: docker/pytango_base
 
 build:ska-sdp-subarray:
   extends: .build_python

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -195,7 +195,7 @@ build:ska-sdp-subarray:
     - twine upload --repository-url $PYPI_REPOSITORY_URL dist/*
 
 .publish_python_master:
-  extends: .build_python
+  extends: .publish_python
   variables:
     BUILD_PATH: src/tango_sdp_master
 
@@ -209,7 +209,7 @@ publish:ska-sdp-master:
   only: [master]
 
 .publish_python_subarray:
-  extends: .build_python
+  extends: .publish_python
   variables:
     BUILD_PATH: src/tango_sdp_subarray
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -134,40 +134,93 @@ xray_report-manual:
   tags:
     - docker
     - engageska
-  script:
-    - cd $BUILD_PATH
-    - python setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
-    - ls
-    - ls dist/
   artifacts:
     paths:
       - ./$BUILD_PATH/dist/
 
-build:ska-sdp-master:
+.build_python_dev:
   extends: .build_python
+  script:
+    - cd $BUILD_PATH
+    - python setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+
+.build_python_release:
+  extends: .build_python
+  script:
+    - cd $BUILD_PATH
+    - python setup.py sdist bdist_wheel
+
+build:ska-sdp-master_dev:
+  extends: .build_python_dev
   variables:
     BUILD_PATH: src/tango_sdp_master
+  except: [master]
 
-build:ska-sdp-subarray:
-  extends: .build_python
+build:ska-sdp-master:
+  extends: .build_python_release
+  variables:
+    BUILD_PATH: src/tango_sdp_master
+  only: [master]
+
+build:ska-sdp-subarray_dev:
+  extends: .build_python_dev
   variables:
     BUILD_PATH: src/tango_sdp_subarray
+  except: [master]
+
+build:ska-sdp-subarray:
+  extends: .build_python_release
+  variables:
+    BUILD_PATH: src/tango_sdp_subarray
+  only: [master]
 
 # ============================================================================
 # Publish python packages
 # ============================================================================
 
-#publish_to_nexus:
-#  stage: publish
-#  image: nexus.engageska-portugal.pt/sdp-prototype/pytango_ska_dev:latest
-#  tags:
-#    - docker
-#    - engageska
-#  before_script:
-#    - pip install twine
-#  script:
-#    - python setup.py sdist bdist_wheel
-#    - twine upload dist/*
+.publish_python:
+  stage: publish
+  image: nexus.engageska-portugal.pt/sdp-prototype/pytango_ska_dev:latest
+  variables:
+    TWINE_USERNAME: $TWINE_USERNAME
+    TWINE_PASSWORD: $TWINE_PASSWORD
+  tags:
+    - docker
+    - engageska
+  before_script:
+    - pip install twine
+  script:
+    - cd $BUILD_PATH
+    - ls
+    - twine upload --repository-url $PYPI_REPOSITORY_URL dist/*
+
+.publish_python_master:
+  extends: .build_python
+  variables:
+    BUILD_PATH: src/tango_sdp_master
+
+publish:ska-sdp-master-manual:
+  extends: .publish_python_master
+  when: manual
+  except: [master]
+
+publish:ska-sdp-master:
+  extends: .publish_python_master
+  only: [master]
+
+.publish_python_subarray:
+  extends: .build_python
+  variables:
+    BUILD_PATH: src/tango_sdp_subarray
+
+publish:ska-sdp-subarray-manual:
+  extends: .publish_python_subarray
+  when: manual
+  except: [master]
+
+publish:ska-sdp-subarray:
+  extends: .publish_python_subarray
+  only: [master]
 
 # ============================================================================
 # Build docker images


### PR DESCRIPTION
Update to the CI script to build and publish the SDP Tango devices to Nexus.

Follows instructions from the ska developer portal: https://developer.skatelescope.org/en/latest/development/python_package_release_procedure.html#building-packages