### PR TITLE
Removed Python 3 type annotations (hints) from the SDPSubarray device class.

### DIFF
--- a/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
+++ b/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
@@ -109,35 +109,35 @@ class SDPSubarray(Device):
     # Attributes methods
     # ------------------
 
-    def write_obsState(self, obs_state: ObsState):
+    def write_obsState(self, obs_state):
         """Set the obsState attribute.
 
         :param obs_state: An observation state enum value.
         """
         self._obs_state = obs_state
 
-    def read_obsState(self) -> ObsState:
+    def read_obsState(self):
         """Get the obsState attribute.
 
         :returns: The current obsState attribute value.
         """
         return self._obs_state
 
-    def write_adminMode(self, admin_mode: AdminMode):
+    def write_adminMode(self, admin_mode):
         """Set the adminMode attribute.
 
         :param admin_mode: An admin mode enum value.
         """
         self._admin_mode = admin_mode
 
-    def read_adminMode(self) -> AdminMode:
+    def read_adminMode(self):
         """Get the adminMode attribute.
 
         :return: The current adminMode attribute value.
         """
         return self._admin_mode
 
-    def read_receiveAddresses(self) -> str:
+    def read_receiveAddresses(self):
         """Get the list of receive addresses encoded as a JSON string.
 
         More details are provided on SKA confluence at the address:
@@ -160,7 +160,7 @@ class SDPSubarray(Device):
 
     @command(dtype_in=str)
     @DebugIt()
-    def AssignResources(self, config: str = ''):
+    def AssignResources(self, config=''):
         """Assign Resources assigned to the subarray device.
 
         This is currently a noop for SDP!
@@ -183,7 +183,7 @@ class SDPSubarray(Device):
 
     @command(dtype_in=str)
     @DebugIt()
-    def ReleaseResources(self, config: str = ''):
+    def ReleaseResources(self, config=''):
         """Release resources assigned to the subarray device.
 
         This is currently a noop for SDP!
@@ -207,7 +207,7 @@ class SDPSubarray(Device):
 
     @command(dtype_in=str)
     @DebugIt()
-    def Configure(self, pb_config: str, schema_path: str = None):
+    def Configure(self, pb_config, schema_path=None):
         """Configure the device to execute a real-time Processing Block (PB).
 
         Provides PB configuration and parameters needed to execute the first
@@ -234,7 +234,7 @@ class SDPSubarray(Device):
 
     @command(dtype_in=str)
     @DebugIt()
-    def ConfigureScan(self, scan_config: str, schema_path: str = None):
+    def ConfigureScan(self, scan_config, schema_path=None):
         """Configure the subarray device to execute a scan.
 
         This allows scan specific, late-binding information to be provided
@@ -283,7 +283,7 @@ class SDPSubarray(Device):
         self._obs_state = ObsState.READY
 
 
-def delete_device_server(instance_name: str = "*"):
+def delete_device_server(instance_name="*"):
     """Delete (unregister) SDPSubarray device server instance(s).
 
     :param instance_name: Optional, name of the device server instance to
@@ -301,7 +301,7 @@ def delete_device_server(instance_name: str = "*"):
         pass
 
 
-def register(instance_name: str, *device_names: str):
+def register(instance_name, *device_names):
     """Register device with a SDPSubarray device server instance.
 
     If the device is already registered, do nothing.
@@ -330,7 +330,7 @@ def register(instance_name: str, *device_names: str):
         pass
 
 
-def init_logger(level: str = 'DEBUG', name: str = 'ska.sdp'):
+def init_logger(level='DEBUG', name='ska.sdp'):
     """Initialise stdout logger for the ska.sdp logger.
 
     :param level: Logging level, default: 'DEBUG'

--- a/src/tango_sdp_subarray/SDPSubarray/release.py
+++ b/src/tango_sdp_subarray/SDPSubarray/release.py
@@ -4,7 +4,7 @@
 # Consider change to: ska-tangods-sdpsubarray ?
 NAME = "ska-sdp-subarray"
 # For version names see: https://www.python.org/dev/peps/pep-0440/
-VERSION = "0.2.1"
+VERSION = "0.2.2"
 VERSION_INFO = VERSION.split(".")
 AUTHOR = "ORCA team"
 LICENSE = 'License :: OSI Approved :: BSD License'


### PR DESCRIPTION
Small change to remove the use of python 3 type annotations from the SDPSubarray device.

This address an issue with pytango 9.2.5 where the use of type hints (also known as type annotations) causes an error in the tango device server which uses the deprecated `inspect.getargspec()` instead of the python 3.0+ `inspect.getfullargspec()`. See https://docs.python.org/3/library/inspect.html#inspect.getargspec.
