### PR TITLE
Update to SDPSubarray Configure schema.

### DIFF
--- a/src/tango_sdp_subarray/SDPSubarray/release.py
+++ b/src/tango_sdp_subarray/SDPSubarray/release.py
@@ -4,7 +4,7 @@
 # Consider change to: ska-tangods-sdpsubarray ?
 NAME = "ska-sdp-subarray"
 # For version names see: https://www.python.org/dev/peps/pep-0440/
-VERSION = "0.3.0"
+VERSION = "0.4.0"
 VERSION_INFO = VERSION.split(".")
 AUTHOR = "ORCA team"
 LICENSE = 'License :: OSI Approved :: BSD License'

--- a/src/tango_sdp_subarray/SDPSubarray/schema/configure_pb.json
+++ b/src/tango_sdp_subarray/SDPSubarray/schema/configure_pb.json
@@ -44,25 +44,30 @@
         "parameters": {
           "type": "object"
         },
-        "scanParameters":
-        {
+        "scanParameters": {
           "type": "object",
-          "scanId": {
-            "type": "integer",
-            "description":"Scan ID. Schema TBD."
-          },
-          "fieldId": {
-            "type": "integer",
-            "description":"Field Id"
-          },
-          "interval": {
-            "type": "number",
-            "description": "Interval between visibility samples, in seconds."
-          },
-          "intervalMs": {
-            "type": "number",
-            "$comment": "DEPRECATED",
-            "description": "Interval between visibility samples, in milliseconds."
+          "patternProperties": {
+            "^.*$": {
+              "type": "object",
+              "required": ["fieldId"],
+              "scanId": {
+                "type": "integer",
+                "description":"Scan ID. Schema TBD."
+              },
+              "fieldId": {
+                "type": "integer",
+                "description":"Field Id"
+              },
+              "interval": {
+                "type": "number",
+                "description": "Interval between visibility samples, in seconds."
+              },
+              "intervalMs": {
+                "type": "number",
+                "$comment": "DEPRECATED",
+                "description": "Interval between visibility samples, in milliseconds."
+              }
+            }
           }
         }
       }

--- a/src/tango_sdp_subarray/tests/data/pb_config.json
+++ b/src/tango_sdp_subarray/tests/data/pb_config.json
@@ -1,32 +1,37 @@
 {
- "configure": {
-   "id": "realtime-20190627-0001",
-   "sbiId": "20190627-0001",
-   "workflow": {
-     "id": "vis_ingest",
-     "type": "realtime",
-     "version": "0.1.0"
-   },
-   "parameters": {
-     "numStations": 4,
-     "numChannels": 372,
-     "numPolarisations": 4,
-     "freqStartHz": 0.35e9,
-     "freqEndHz": 1.05e9,
-     "fields": {
-       "0": {
-         "system": "ICRS",
-         "name": "NGC6251",
-         "ra": "2:31:50.91",
-         "dec": "89:15:51.4"
-       }
-     }
-   },
-   "scanParameters": {
-     "12345": {
-       "fieldId": 0,
-       "intervalMs": 1400
-     }
-   }
- }
+  "configure": {
+    "workflow":
+    {
+      "type": "realtime",
+      "version": "0.1.0",
+      "id": "vis_ingest"
+    },
+    "sbiId": "20190627-0001",
+    "parameters": {
+      "numStations": 4,
+      "numPolarisations": 4,
+      "numChannels": 372,
+      "freqEndHz": 1050000000.0,
+      "freqStartHz": 350000000.0,
+      "fields": {
+        "0": {
+          "name": "NGC6251",
+          "dec": "89:15:51.4",
+          "system": "ICRS",
+          "ra": "2:31:50.91"
+        }
+      }
+    },
+    "scanParameters": {
+      "12345": {
+        "intervalMs": 1400,
+        "fieldId": 0
+      },
+      "12346": {
+        "intervalMs": 1400,
+        "fieldId": 0
+      }
+    },
+    "id": "realtime-20190627-0001"
+  }
 }

--- a/src/tango_sdp_subarray/tests/data/pb_config.old.json
+++ b/src/tango_sdp_subarray/tests/data/pb_config.old.json
@@ -1,0 +1,32 @@
+{
+ "configure": {
+   "id": "realtime-20190627-0001",
+   "sbiId": "20190627-0001",
+   "workflow": {
+     "id": "vis_ingest",
+     "type": "realtime",
+     "version": "0.1.0"
+   },
+   "parameters": {
+     "numStations": 4,
+     "numChannels": 372,
+     "numPolarisations": 4,
+     "freqStartHz": 0.35e9,
+     "freqEndHz": 1.05e9,
+     "fields": {
+       "0": {
+         "system": "ICRS",
+         "name": "NGC6251",
+         "ra": "2:31:50.91",
+         "dec": "89:15:51.4"
+       }
+     }
+   },
+   "scanParameters": {
+     "12345": {
+       "fieldId": 0,
+       "intervalMs": 1400
+     }
+   }
+ }
+}


### PR DESCRIPTION
allows scanParameters to be a set of objects with the scan id as the primary key.