### PR TITLE
Fix Xray for failed tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,7 +212,8 @@ coverage_report:
 # Update XRay links in JIRA automatically This is done only for the master
 xray_report:
   extends: .xray_report
-  only: [master]
+  when: always
+  only: [feature-fix-xray-for-failed-tests]
 
 # Update XRay links in JIRA. Manual job that can be executed for branches
 xray_report-manual:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,6 +47,7 @@ subarray_device_tests:
     - cucumber.json
     - $CI_JOB_NAME.coverage
     expire_in: 1 week
+    when: always
 
 # Test the SDPMaster device.
 master_device_tests:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -214,7 +214,7 @@ coverage_report:
 xray_report:
   extends: .xray_report
   when: always
-  only: [feature-fix-xray-for-failed-tests]
+  only: [master]
 
 # Update XRay links in JIRA. Manual job that can be executed for branches
 xray_report-manual:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -204,7 +204,7 @@ coverage_report:
   tags: [docker]
   image: python:latest
   script:
-    - 'curl -X POST -H "Content-Type: application/json"
+    - 'curl -X POST -H "Content-Type: application/json" --fail
          -H "Authorization: Basic $JIRA_AUTH"
          --data @cucumber.json
          https://jira.skatelescope.org/rest/raven/1.0/import/execution/cucumber'

--- a/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
+++ b/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
@@ -220,7 +220,7 @@ class SDPSubarray(Device):
         :param schema_path: Path to the PB config schema (optional).
         """
         # pylint: disable=unused-argument
-        self._obs_state = ObsState.CONFIGURING
+        self._obs_state = ObsState.SILLY
         # time.sleep(1)
 
         # Validate the SBI config schema

--- a/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
+++ b/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
@@ -220,7 +220,7 @@ class SDPSubarray(Device):
         :param schema_path: Path to the PB config schema (optional).
         """
         # pylint: disable=unused-argument
-        self._obs_state = ObsState.SILLY
+        self._obs_state = ObsState.CONFIGURING
         # time.sleep(1)
 
         # Validate the SBI config schema


### PR DESCRIPTION
Noticed that we had not properly addressed that Xray jobs would not run if tests failed. This adjusts the `.gitlab-ci.yml` accordingly.

Also added `--fail` to the `curl` command line, so the step actually fails if JIRA is uncooperative (as it happens to be right now, so we might want to delay merging this a bit)