### PR TITLE
EndScan sets receiveAddresses to null

### DIFF
--- a/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
+++ b/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
@@ -364,6 +364,7 @@ class SDPSubarray(Device):
     def EndScan(self):
         """Command issued when the scan is ended."""
         self._require_obs_state([ObsState.SCANNING])
+        self._recv_addresses = None
         self._obs_state = ObsState.READY
 
     @command

--- a/src/tango_sdp_subarray/SDPSubarray/release.py
+++ b/src/tango_sdp_subarray/SDPSubarray/release.py
@@ -4,7 +4,7 @@
 # Consider change to: ska-tangods-sdpsubarray ?
 NAME = "ska-sdp-subarray"
 # For version names see: https://www.python.org/dev/peps/pep-0440/
-VERSION = "0.5.6"
+VERSION = "0.5.7"
 VERSION_INFO = VERSION.split(".")
 AUTHOR = "ORCA team"
 LICENSE = 'License :: OSI Approved :: BSD License'

--- a/src/tango_sdp_subarray/tests/1_XR-11.feature
+++ b/src/tango_sdp_subarray/tests/1_XR-11.feature
@@ -107,3 +107,4 @@ Feature: SDPSubarray device
 		When obsState is SCANNING
 		And I call EndScan
 		Then obsState should be READY
+		Then The receiveAddresses attribute returns an empty JSON object

--- a/src/tango_sdp_subarray/tests/test_subarray_device.py
+++ b/src/tango_sdp_subarray/tests/test_subarray_device.py
@@ -258,10 +258,20 @@ def receive_addresses_attribute_ok(subarray_device):
     :param subarray_device: An SDPSubarray device.
     """
     receive_addresses = subarray_device.receiveAddresses
-    print(json.dumps(json.loads(receive_addresses), indent=2))
+    # print(json.dumps(json.loads(receive_addresses), indent=2))
     expected_output_file = join(dirname(__file__), 'data',
                                 'receiveAddresses-empty.json')
     with open(expected_output_file, 'r') as file:
         expected = json.loads(file.read())
     receive_addresses = json.loads(receive_addresses)
     assert receive_addresses == expected
+
+
+@then('The receiveAddresses attribute returns an empty JSON object')
+def receive_addresses_empty(subarray_device):
+    """Check that receiveAddresss attribute returns an empty JSON object.
+
+    :param subarray_device: An SDPSubarray device.
+    """
+    receive_addresses = subarray_device.receiveAddresses
+    assert str(receive_addresses) == 'null'


### PR DESCRIPTION
Set `receiveAddresses` attribute to return null at the end of the scan.

I've updated the `EndScan command successful` scenario in the unit tests to validate against this.