### PR TITLE
Quick hack to address a couple of Configure failure modes.

### DIFF
--- a/src/tango_sdp_subarray/SDPSubarray/release.py
+++ b/src/tango_sdp_subarray/SDPSubarray/release.py
@@ -4,7 +4,7 @@
 # Consider change to: ska-tangods-sdpsubarray ?
 NAME = "ska-sdp-subarray"
 # For version names see: https://www.python.org/dev/peps/pep-0440/
-VERSION = "0.5.12"
+VERSION = "0.5.13"
 VERSION_INFO = VERSION.split(".")
 AUTHOR = "ORCA team"
 LICENSE = 'License :: OSI Approved :: BSD License'


### PR DESCRIPTION
This updates the subarray device image to `nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_subarray:0.5.13` and handles some failure modes due that mean that configure can get stuck if not provided with the example configuration.

Note these are not long term fixes and just address a short term issue by catching a number of conditions with bad, missing, or poorly defined config. A complete rework of this device to address failure modes will be still needed in future.
