### PR TITLE
Add feature toggle to enable/disable tango-db auto registration.

### DIFF
--- a/src/tango_sdp_master/SDPMaster/release.py
+++ b/src/tango_sdp_master/SDPMaster/release.py
@@ -3,7 +3,7 @@
 
 NAME = "ska-sdp-master"
 # For version names see: https://www.python.org/dev/peps/pep-0440/
-VERSION = "0.2.1"
+VERSION = "0.2.2"
 VERSION_INFO = VERSION.split(".")
 AUTHOR = "ORCA Team"
 LICENSE = 'License :: OSI Approved :: BSD License'

--- a/src/tango_sdp_subarray/SDPSubarray/release.py
+++ b/src/tango_sdp_subarray/SDPSubarray/release.py
@@ -4,7 +4,7 @@
 # Consider change to: ska-tangods-sdpsubarray ?
 NAME = "ska-sdp-subarray"
 # For version names see: https://www.python.org/dev/peps/pep-0440/
-VERSION = "0.5.13"
+VERSION = "0.5.14"
 VERSION_INFO = VERSION.split(".")
 AUTHOR = "ORCA team"
 LICENSE = 'License :: OSI Approved :: BSD License'


### PR DESCRIPTION
The feature toggle is set by the value of the env variable:
    TOGGLE_AUTO_REGISTER = 0 (disabled) or 1 (enabled)

By default this feature is enabled to maintain current behaviour.