### PR TITLE
SIM-129 Subarray device state transitions

### DIFF
--- a/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
+++ b/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
@@ -327,7 +327,7 @@ class SDPSubarray(Device):
 
         # 1. Check obsState is IDLE, and set to CONFIGURING
         self._require_obs_state([ObsState.IDLE])
-        self._set_obs_state(ObsState.CONFIGURING)
+        # self._set_obs_state(ObsState.CONFIGURING)
         self.set_state(DevState.ON)
 
         # 2. Validate the Configure JSON object argument
@@ -566,10 +566,10 @@ class SDPSubarray(Device):
 
         """
         LOG.debug('Validating Configure JSON (PB configuration).')
-        if json_str == '':
-            self._set_obs_state(ObsState.FAULT)
-            self._receive_addresses = None
-            self._raise_command_error('Empty JSON configuration!')
+        # if json_str == '':
+        #     self._set_obs_state(ObsState.FAULT)
+        #     self._receive_addresses = None
+        #     self._raise_command_error('Empty JSON configuration!')
 
         schema_path = join(dirname(__file__), 'schema', 'configure_pb.json')
         config = {}
@@ -578,19 +578,26 @@ class SDPSubarray(Device):
             with open(schema_path, 'r') as file:
                 schema = json.loads(file.read())
             validate(config, schema)
-        except json.JSONDecodeError as error:
-            msg = 'Unable to load JSON configuration: {}'.format(error.msg)
-            self._set_obs_state(ObsState.FAULT)
-            self._receive_addresses = None
-            self._raise_command_error(msg)
-        except exceptions.ValidationError as error:
-            msg = 'Configure JSON validation error: {}'.format(
-                error.message)
-            self._set_obs_state(ObsState.FAULT)
-            self._receive_addresses = None
-            frame_info = getframeinfo(currentframe())
-            origin = '{}:{}'.format(frame_info.filename, frame_info.lineno)
-            self._raise_command_error(msg, origin)
+        except:
+            pass
+        # try:
+        #     config = json.loads(json_str)
+        #     with open(schema_path, 'r') as file:
+        #         schema = json.loads(file.read())
+        #     validate(config, schema)
+        # except json.JSONDecodeError as error:
+        #     msg = 'Unable to load JSON configuration: {}'.format(error.msg)
+        #     self._set_obs_state(ObsState.FAULT)
+        #     self._receive_addresses = None
+        #     self._raise_command_error(msg)
+        # except exceptions.ValidationError as error:
+        #     msg = 'Configure JSON validation error: {}'.format(
+        #         error.message)
+        #     self._set_obs_state(ObsState.FAULT)
+        #     self._receive_addresses = None
+        #     frame_info = getframeinfo(currentframe())
+        #     origin = '{}:{}'.format(frame_info.filename, frame_info.lineno)
+        #     self._raise_command_error(msg, origin)
 
         LOG.debug('Successfully validated Configure JSON argument!')
         return config

--- a/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
+++ b/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
@@ -327,7 +327,7 @@ class SDPSubarray(Device):
 
         # 1. Check obsState is IDLE, and set to CONFIGURING
         self._require_obs_state([ObsState.IDLE])
-        # self._set_obs_state(ObsState.CONFIGURING)
+        self._set_obs_state(ObsState.CONFIGURING)
         self.set_state(DevState.ON)
 
         # 2. Validate the Configure JSON object argument
@@ -566,10 +566,10 @@ class SDPSubarray(Device):
 
         """
         LOG.debug('Validating Configure JSON (PB configuration).')
-        # if json_str == '':
-        #     self._set_obs_state(ObsState.FAULT)
-        #     self._receive_addresses = None
-        #     self._raise_command_error('Empty JSON configuration!')
+        if json_str == '':
+            self._set_obs_state(ObsState.FAULT)
+            self._receive_addresses = None
+            self._raise_command_error('Empty JSON configuration!')
 
         schema_path = join(dirname(__file__), 'schema', 'configure_pb.json')
         config = {}
@@ -578,26 +578,19 @@ class SDPSubarray(Device):
             with open(schema_path, 'r') as file:
                 schema = json.loads(file.read())
             validate(config, schema)
-        except:
-            pass
-        # try:
-        #     config = json.loads(json_str)
-        #     with open(schema_path, 'r') as file:
-        #         schema = json.loads(file.read())
-        #     validate(config, schema)
-        # except json.JSONDecodeError as error:
-        #     msg = 'Unable to load JSON configuration: {}'.format(error.msg)
-        #     self._set_obs_state(ObsState.FAULT)
-        #     self._receive_addresses = None
-        #     self._raise_command_error(msg)
-        # except exceptions.ValidationError as error:
-        #     msg = 'Configure JSON validation error: {}'.format(
-        #         error.message)
-        #     self._set_obs_state(ObsState.FAULT)
-        #     self._receive_addresses = None
-        #     frame_info = getframeinfo(currentframe())
-        #     origin = '{}:{}'.format(frame_info.filename, frame_info.lineno)
-        #     self._raise_command_error(msg, origin)
+        except json.JSONDecodeError as error:
+            msg = 'Unable to load JSON configuration: {}'.format(error.msg)
+            self._set_obs_state(ObsState.FAULT)
+            self._receive_addresses = None
+            self._raise_command_error(msg)
+        except exceptions.ValidationError as error:
+            msg = 'Configure JSON validation error: {}'.format(
+                error.message)
+            self._set_obs_state(ObsState.FAULT)
+            self._receive_addresses = None
+            frame_info = getframeinfo(currentframe())
+            origin = '{}:{}'.format(frame_info.filename, frame_info.lineno)
+            self._raise_command_error(msg, origin)
 
         LOG.debug('Successfully validated Configure JSON argument!')
         return config

--- a/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
+++ b/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
@@ -568,8 +568,8 @@ class SDPSubarray(Device):
         LOG.debug('Validating Configure JSON (PB configuration).')
         if json_str == '':
             self._set_obs_state(ObsState.IDLE)
-            # self._receive_addresses = None
-            # self._raise_command_error('Empty JSON configuration!')
+            self._receive_addresses = None
+            self._raise_command_error('Empty JSON configuration!')
 
         schema_path = join(dirname(__file__), 'schema', 'configure_pb.json')
         config = {}

--- a/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
+++ b/src/tango_sdp_subarray/SDPSubarray/SDPSubarray.py
@@ -332,7 +332,7 @@ class SDPSubarray(Device):
 
         # 2. Validate the Configure JSON object argument
         config = self._validate_configure_json(json_config)
-        LOG.debug('Configure JSON successfully validated.')
+        # LOG.debug('Configure JSON successfully validated.')
         config = config.get('configure')
         self._config = config  # Store local copy of the configuration dict
         configured_scans = [int(scan_id) for scan_id in
@@ -567,9 +567,9 @@ class SDPSubarray(Device):
         """
         LOG.debug('Validating Configure JSON (PB configuration).')
         if json_str == '':
-            self._set_obs_state(ObsState.FAULT)
-            self._receive_addresses = None
-            self._raise_command_error('Empty JSON configuration!')
+            self._set_obs_state(ObsState.IDLE)
+            # self._receive_addresses = None
+            # self._raise_command_error('Empty JSON configuration!')
 
         schema_path = join(dirname(__file__), 'schema', 'configure_pb.json')
         config = {}
@@ -580,13 +580,13 @@ class SDPSubarray(Device):
             validate(config, schema)
         except json.JSONDecodeError as error:
             msg = 'Unable to load JSON configuration: {}'.format(error.msg)
-            self._set_obs_state(ObsState.FAULT)
+            self._set_obs_state(ObsState.IDLE)
             self._receive_addresses = None
             self._raise_command_error(msg)
         except exceptions.ValidationError as error:
             msg = 'Configure JSON validation error: {}'.format(
                 error.message)
-            self._set_obs_state(ObsState.FAULT)
+            self._set_obs_state(ObsState.IDLE)
             self._receive_addresses = None
             frame_info = getframeinfo(currentframe())
             origin = '{}:{}'.format(frame_info.filename, frame_info.lineno)

--- a/src/tango_sdp_subarray/tests/1_XR-11.feature
+++ b/src/tango_sdp_subarray/tests/1_XR-11.feature
@@ -89,7 +89,7 @@ Feature: SDPSubarray device
 		Given I have an ONLINE SDPSubarray device
 		When obsState is IDLE
 		And I call Configure with invalid JSON
-		Then obsState should be FAULT
+		Then obsState should be IDLE
 		And The receiveAddresses attribute should return an empty JSON object
 
 

--- a/src/tango_sdp_subarray/tests/test_subarray_device.py
+++ b/src/tango_sdp_subarray/tests/test_subarray_device.py
@@ -170,6 +170,7 @@ def command_configure_invalid_json(subarray_device):
     with pytest.raises(tango.DevFailed):
         subarray_device.Configure('{}')
 
+        
 @when('I call ConfigureScan')
 def command_configure_scan(subarray_device):
     """Call the Configure Scan command.

--- a/src/tango_sdp_subarray/tests/test_subarray_device.py
+++ b/src/tango_sdp_subarray/tests/test_subarray_device.py
@@ -171,6 +171,7 @@ def command_configure_invalid_json(subarray_device):
         subarray_device.Configure('{}')
 
 
+
 @when('I call ConfigureScan')
 def command_configure_scan(subarray_device):
     """Call the Configure Scan command.

--- a/src/tango_sdp_subarray/tests/test_subarray_device.py
+++ b/src/tango_sdp_subarray/tests/test_subarray_device.py
@@ -167,8 +167,10 @@ def command_configure_invalid_json(subarray_device):
 
     :param subarray_device: An SDPSubarray device.
     """
-    with pytest.raises(tango.DevFailed):
-        subarray_device.Configure('{}')
+    # with pytest.raises(tango.DevFailed):
+    #     subarray_device.Configure('{}')
+
+    subarray_device.Configure('{}')
 
 
 

--- a/src/tango_sdp_subarray/tests/test_subarray_device.py
+++ b/src/tango_sdp_subarray/tests/test_subarray_device.py
@@ -167,12 +167,8 @@ def command_configure_invalid_json(subarray_device):
 
     :param subarray_device: An SDPSubarray device.
     """
-    # with pytest.raises(tango.DevFailed):
-    #     subarray_device.Configure('{}')
-
-    subarray_device.Configure('{}')
-
-
+    with pytest.raises(tango.DevFailed):
+        subarray_device.Configure('{}')
 
 @when('I call ConfigureScan')
 def command_configure_scan(subarray_device):

--- a/src/tango_sdp_subarray/tests/test_subarray_device.py
+++ b/src/tango_sdp_subarray/tests/test_subarray_device.py
@@ -170,7 +170,7 @@ def command_configure_invalid_json(subarray_device):
     with pytest.raises(tango.DevFailed):
         subarray_device.Configure('{}')
 
-        
+
 @when('I call ConfigureScan')
 def command_configure_scan(subarray_device):
     """Call the Configure Scan command.


### PR DESCRIPTION
Updated the configure command to change state to IDLE when the JSON validation fails.

Can be tested by using either of the commands inside tango_sdp_subarray folder:

make test
or 
make test_only