### PR TITLE
Tango 933 update

### DIFF
--- a/deploy/charts/sdp-prototype/charts/tango-base/values.yaml
+++ b/deploy/charts/sdp-prototype/charts/tango-base/values.yaml
@@ -35,7 +35,7 @@ databaseds:
       memory: 256Mi # 256Mi = 0.25 GB mem
 
 itango:
-  enabled: false
+  enabled: true
   image:
     registry: nexus.engageska-portugal.pt/ska-docker
     image: tango-itango

--- a/deploy/charts/sdp-prototype/values.yaml
+++ b/deploy/charts/sdp-prototype/values.yaml
@@ -55,11 +55,11 @@ workflow:
 tango:
   master:
     image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_master
-    version: 0.2.1
+    version: 0.2.3
     imagePullPolicy: IfNotPresent
   subarray:
     image: nexus.engageska-portugal.pt/sdp-prototype/tangods_sdp_subarray
-    version: 0.5.15
+    version: 0.5.16
     imagePullPolicy: IfNotPresent
 
 # Parameters for sub-chart

--- a/src/tango_sdp_master/Dockerfile
+++ b/src/tango_sdp_master/Dockerfile
@@ -1,14 +1,5 @@
-ARG DOCKER_REGISTRY_USER
-ARG DOCKER_REGISTRY_HOST
-FROM ${DOCKER_REGISTRY_HOST}/${DOCKER_REGISTRY_USER}/pytango_ska_base:latest
-
-WORKDIR /app
-COPY . /app
-
-COPY Pipfile Pipfile
-COPY Pipfile.lock Pipfile.lock
-
-RUN pipenv install --deploy --ignore-pipfile --dev
+FROM nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:latest AS buildenv
+FROM nexus.engageska-portugal.pt/ska-docker/ska-python-runtime:latest AS runtime
 
 ENTRYPOINT ["python", "SDPMaster"]
 CMD ["1", "-v4"]

--- a/src/tango_sdp_master/SDPMaster/release.py
+++ b/src/tango_sdp_master/SDPMaster/release.py
@@ -3,7 +3,7 @@
 
 NAME = "ska-sdp-master"
 # For version names see: https://www.python.org/dev/peps/pep-0440/
-VERSION = "0.2.2"
+VERSION = "0.2.3"
 VERSION_INFO = VERSION.split(".")
 AUTHOR = "ORCA Team"
 LICENSE = 'License :: OSI Approved :: BSD License'

--- a/src/tango_sdp_subarray/Dockerfile
+++ b/src/tango_sdp_subarray/Dockerfile
@@ -1,14 +1,5 @@
-ARG DOCKER_REGISTRY_USER
-ARG DOCKER_REGISTRY_HOST
-FROM ${DOCKER_REGISTRY_HOST}/${DOCKER_REGISTRY_USER}/pytango_ska_base:latest as build
-
-WORKDIR /app
-COPY . /app
-
-COPY Pipfile Pipfile
-COPY Pipfile.lock Pipfile.lock
-
-RUN pipenv install --deploy --ignore-pipfile --dev
+FROM nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:latest AS buildenv
+FROM nexus.engageska-portugal.pt/ska-docker/ska-python-runtime:latest AS runtime
 
 ENTRYPOINT ["python", "SDPSubarray"]
 CMD ["1", "-v4"]

--- a/src/tango_sdp_subarray/SDPSubarray/release.py
+++ b/src/tango_sdp_subarray/SDPSubarray/release.py
@@ -4,7 +4,7 @@
 # Consider change to: ska-tangods-sdpsubarray ?
 NAME = "ska-sdp-subarray"
 # For version names see: https://www.python.org/dev/peps/pep-0440/
-VERSION = "0.5.15"
+VERSION = "0.5.16"
 VERSION_INFO = VERSION.split(".")
 AUTHOR = "ORCA team"
 LICENSE = 'License :: OSI Approved :: BSD License'


### PR DESCRIPTION
Update SDP Tango devices (`SDPMaster` & `SDPSubarray`) to use the `ska-docker` base images with TANGO 9.3.3 and PyTango 9.3.1.

A manual test of these can be done using the helm char in the `deploy/charts` folder.