### PR TITLE
Let users set the path to charts in the git repo

### DIFF
--- a/deploy/charts/sdp-prototype/templates/helm-deploy-controller.yml
+++ b/deploy/charts/sdp-prototype/templates/helm-deploy-controller.yml
@@ -31,6 +31,8 @@ spec:
           value: "{{ .Values.helm_deploy.chart_repo.url }}"
         - name: SDP_CHART_REPO_REF
           value: "{{ .Values.helm_deploy.chart_repo.ref }}"
+        - name: SDP_CHART_REPO_PATH
+          value: "{{ .Values.helm_deploy.chart_repo.path }}"
         - name: SDP_CHART_REPO_REFRESH
           value: "{{ .Values.helm_deploy.chart_repo.refresh }}"
       serviceAccountName: {{ include "sdp-prototype.fullname" . }}-helm

--- a/deploy/charts/sdp-prototype/values.yaml
+++ b/deploy/charts/sdp-prototype/values.yaml
@@ -14,6 +14,7 @@ helm_deploy:
   chart_repo:
     url: https://github.com/ska-telescope/sdp-prototype.git
     ref: master
+    path: deploy/charts
     refresh: 300
 
 # Configuration database


### PR DESCRIPTION
This setting was missing from the full set, but was something I needed
to modify in order to launch an sdp-prototype release that could
instantiate charts coming from our repository, which are not stored
under deploy/charts.